### PR TITLE
Continue organizing engine networking code

### DIFF
--- a/subprojects/little-hell-engine/meson.build
+++ b/subprojects/little-hell-engine/meson.build
@@ -224,7 +224,7 @@ if meson.is_subproject()
       include_directories: [
         include_directories(libs_src_dir),
         include_directories(src_dir),
-        #include_directories(littlehell_include_dir)
+        include_directories(littlehell_include_dir)
       ]
     )
 endif

--- a/subprojects/little-hell-engine/src/net/dedicated.c
+++ b/subprojects/little-hell-engine/src/net/dedicated.c
@@ -25,9 +25,9 @@
 
 #include "m_argv.h"
 
-#include "net_common.h"
-#include "net_sdl.h"
-#include "net_server.h"
+#include "net/common.h"
+#include "net/sdl.h"
+#include "net/server.h"
 
 //
 // People can become confused about how dedicated servers work.  Game

--- a/subprojects/little-hell-engine/src/net/packet.c
+++ b/subprojects/little-hell-engine/src/net/packet.c
@@ -18,7 +18,7 @@
 #include <ctype.h>
 #include <string.h>
 #include "m_misc.h"
-#include "net_packet.h"
+#include "net/packet.h"
 #include "z_zone.h"
 
 static int total_packet_memory = 0;


### PR DESCRIPTION
We missed a few includes and a Meson tweak. But now we should be ready to rename all of the `#include`s in the game code after this.